### PR TITLE
Adding nib plugin to stylus compiler.

### DIFF
--- a/examples/css/index.styl
+++ b/examples/css/index.styl
@@ -1,5 +1,10 @@
+@import 'nib'
 
+html
+body
+  height 100%
 
-body {
-  font: 12px Helvetica, Arial, sans-serif;
-}
+body
+  margin 0
+  font 12px Helvetica, Arial, sans-serif
+  background linear-gradient(top, transparent, rgba(0,0,0,.2) 30%)

--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -6,5 +6,6 @@
     <link rel="stylesheet" href="/application.css" type="text/css" media="screen" title="no title" charset="utf-8">
   </head>
   <body>
+      Test
   </body>
 </html>

--- a/examples/slug.json
+++ b/examples/slug.json
@@ -2,5 +2,5 @@
   "libs": [
    "./lib/custom.js"
   ],
-  "dependencies": ["gfx"]
+  "dependencies": []
 }

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -1,5 +1,5 @@
 (function() {
-  var compilers, cs, dirname, eco, fs, stylus;
+  var compilers, cs, dirname, eco, fs, nib, stylus;
   fs = require('fs');
   dirname = require('path').dirname;
   compilers = {};
@@ -43,11 +43,12 @@
   };
   try {
     stylus = require('stylus');
+    nib = require('nib');
     compilers.styl = function(path) {
       var content, result;
       content = fs.readFileSync(path, 'utf8');
       result = '';
-      stylus(content).include(dirname(path)).render(function(err, css) {
+      stylus(content).include(dirname(path)).use(nib()).render(function(err, css) {
         if (err) {
           throw err;
         }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "optimist": "~0.2.6",
     "coffee-script" : "~1.1.2",
     "stylus" : "~0.19.0",
+    "nib": "~0.2.0",
     "watch" : "~0.4.0"
   }
 }

--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -50,12 +50,14 @@ require.extensions['.tmpl'] = (module, filename) ->
   
 try
   stylus = require('stylus')
+  nib    = require('nib')
   
   compilers.styl = (path) ->
     content = fs.readFileSync(path, 'utf8')
     result = ''
     stylus(content)
       .include(dirname(path))
+      .use(nib())
       .render((err, css) -> 
         throw err if err
         result = css


### PR DESCRIPTION
Alex,

Another little one :) just adding [nib](http://visionmedia.github.com/nib/) support to stylus.

I originally needed nib for my spine project(which used hem as well) and could not find another solution as including it directly into hem. But I think it's a great addition to hem since nib provide great CSS helpers. 

Despite of this, if you think it's not modular enough, maybe you'll have an idea for stylus' plugins support for hem.

Let me know.

Cheers
