### PR TITLE
Add Jade template support

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -17,17 +17,17 @@ catch err
 
 eco = require 'eco'
 
-compilers.eco = (path) -> 
+compilers.eco = (path) ->
   content = eco.precompile fs.readFileSync path, 'utf8'
   "module.exports = #{content}"
 
-compilers.jeco = (path) -> 
+compilers.jeco = (path) ->
   content = eco.precompile fs.readFileSync path, 'utf8'
   """
-  module.exports = function(values){ 
+  module.exports = function(values){
     var $  = jQuery, result = $();
     values = $.makeArray(values);
-    
+
     for(var i=0; i < values.length; i++) {
       var value = values[i];
       var elem  = $((#{content})(value));
@@ -40,29 +40,37 @@ compilers.jeco = (path) ->
 
 require.extensions['.jeco'] = require.extensions['.eco']
 
+try
+  jade = require 'jade'
+  compilers.jade = (path) ->
+    content = fs.readFileSync path, 'utf8'
+    fn = jade.compile content, client: true, filename: path
+    "module.exports = #{fn.toString()}"
+catch err
+
 compilers.tmpl = (path) ->
   content = fs.readFileSync(path, 'utf8')
   "var template = jQuery.template(#{JSON.stringify(content)});\n" +
   "module.exports = (function(data){ return jQuery.tmpl(template, data); });\n"
 
-require.extensions['.tmpl'] = (module, filename) -> 
+require.extensions['.tmpl'] = (module, filename) ->
   module._compile(compilers.tmpl(filename))
-  
+
 try
   stylus = require('stylus')
-  
+
   compilers.styl = (path) ->
     content = fs.readFileSync(path, 'utf8')
     result = ''
     stylus(content)
       .include(dirname(path))
-      .render((err, css) -> 
+      .render((err, css) ->
         throw err if err
         result = css
       )
     result
-    
-  require.extensions['.styl'] = (module, filename) -> 
+
+  require.extensions['.styl'] = (module, filename) ->
     source = JSON.stringify(compilers.styl(filename))
     module._compile "module.exports = #{source}", filename
 catch err


### PR DESCRIPTION
Support [Jade](http://jade-lang.com/) templates. Requires adding `jade` module to `package.json`, `jade/runtime` dependency to `slug.json`, and `window.jade = require 'jade/runtime'` to `setup.coffee`.

Example `package.json`:

``` js
{
  "name": "app",
  "version": "0.0.1",
  "dependencies": {
    "es5-shimify": "~0.0.1",
    "hem": "~0.1.6",
    "jade": "~0.17.0",
    "jqueryify": "~0.0.1",
    "json2ify": "~0.0.1",
    "serveup": "~0.0.2",
    "spine": "~1.0.5"
  }
}
```

Example `slug.json`:

``` js
{
  "dependencies": [
    "es5-shimify",
    "jade/runtime",
    "jqueryify",
    "json2ify",
    "spine",
    "spine/lib/ajax",
    "spine/lib/local",
    "spine/lib/manager",
    "spine/lib/route",
    "spine/lib/tmpl"
  ],
  "libs": []
}
```

Example `setup.coffee`:

``` coffeescript
window.jade = require 'jade/runtime'

require 'json2ify'
require 'es5-shimify'
require 'jqueryify'

require 'spine'
require 'spine/lib/local'
require 'spine/lib/ajax'
require 'spine/lib/manager'
require 'spine/lib/route'
require 'spine/lib/tmpl'
```
