### PR TITLE
Fixed how Hem watches CSS files

### DIFF
--- a/lib/hem.js
+++ b/lib/hem.js
@@ -116,7 +116,7 @@
           _results2.push(path.dirname(lib));
         }
         return _results2;
-      }).call(this)).concat(this.options.css, this.options.paths);
+      }).call(this)).concat(path.dirname(this.options.css), this.options.paths);
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         dir = _ref[_i];

--- a/src/hem.coffee
+++ b/src/hem.coffee
@@ -80,7 +80,7 @@ class Hem
 
   watch: ->
     @build() 
-    for dir in (path.dirname(lib) for lib in @options.libs).concat @options.css, @options.paths
+    for dir in (path.dirname(lib) for lib in @options.libs).concat path.dirname(@options.css), @options.paths
       continue unless path.existsSync(dir)
       require('watch').watchTree dir, (file, curr, prev) =>
         if curr and (curr.nlink is 0 or +curr.mtime isnt +prev?.mtime)


### PR DESCRIPTION
Previous to this fix, hem could not watch changes in CSS files.
This was happening because you specify your css file in slug.json like this:

```
"css": "./css/style"
```

However, when in watch mode, hem tries to watch that _directory_. But it is a file.
