### PR TITLE
adding multiple css file support

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -1,24 +1,25 @@
 (function() {
-  var CSS, compilers, resolve;
+  var CSS, compilers, resolve, toArray;
 
   resolve = require('path').resolve;
 
   compilers = require('./compilers');
 
+  toArray = require('./utils').toArray;
+
   CSS = (function() {
 
-    function CSS(path) {
-      try {
-        this.path = require.resolve(resolve(path));
-      } catch (e) {
-
-      }
+    function CSS(paths) {
+      this.paths = toArray(paths).map(this.try_resolve).filter((function(path) {
+        return !!path;
+      }));
     }
 
     CSS.prototype.compile = function() {
-      if (!this.path) return;
-      delete require.cache[this.path];
-      return require(this.path);
+      return this.paths.map(function(path) {
+        delete require.cache[path];
+        return require(path);
+      }).join('');
     };
 
     CSS.prototype.createServer = function() {
@@ -28,6 +29,16 @@
           'Content-Type': 'text/css'
         }, _this.compile());
       };
+    };
+
+    CSS.prototype.try_resolve = function(file) {
+      try {
+        file = require.resolve(resolve(file));
+        return file;
+      } catch (e) {
+        console.log(e);
+      }
+      return null;
     };
 
     return CSS;

--- a/src/css.coffee
+++ b/src/css.coffee
@@ -1,22 +1,32 @@
 {resolve} = require('path')
 compilers = require('./compilers')
+{toArray} = require('./utils')
 
 class CSS
-  constructor: (path) ->
-    try
-      @path = require.resolve(resolve(path))
-    catch e
-    
+  constructor: (paths) ->
+    @paths = toArray(paths).map(@try_resolve).filter(((path) -> !!path))
+
   compile: ->
-    return unless @path
-    delete require.cache[@path]
-    require(@path)
+    @paths.map((path) ->
+      delete require.cache[path]
+      require(path)
+    ).join('')
+
   
   createServer: ->
     (env, callback) =>
       callback(200, 
         'Content-Type': 'text/css', 
         @compile())
+
+  try_resolve: (file) ->
+    try
+      file = require.resolve(resolve(file))
+      return file
+    catch e
+      console.log(e)
+    return null
+
       
 module.exports = 
   CSS: CSS


### PR DESCRIPTION
I have added the ability to support multiple css includes and maintain current compatibility. This was added to support the use of plain old css files in addition to stylus. This is needed because some plain old css libraries do not parse by stylus due to white space issues.

In addition to `{ "css": "./css" }` being supported, `{ "css": ["./css", "./css/other"] }` is also supported with this pull request.
