### PR TITLE
HTML5 history support with catch-all file for hem server.

### DIFF
--- a/lib/hem.js
+++ b/lib/hem.js
@@ -47,7 +47,8 @@
       css: './css',
       libs: [],
       public: './public',
-      catchAll: './public/index.html',
+      catchAll: false,
+      catchAllFile: './public/index.html',
       paths: ['./app'],
       dependencies: [],
       port: process.env.PORT || argv.port || 9294,
@@ -91,14 +92,14 @@
       if (path.existsSync(this.options.public)) {
         this.app.use(strata.static, this.options.public, ['index.html', 'index.htm']);
       }
-      if (path.existsSync(this.options.catchAll)) {
+      if (this.options.catchAll && path.existsSync(this.options.catchAllFile)) {
         this.app.get(/.+/, function(env, callback) {
-          return fs.stat(_this.options.catchAll, function(err, stats) {
+          return fs.stat(_this.options.catchAllFile, function(err, stats) {
             return callback(200, {
               'Content-Type': 'text/html',
               'Content-Length': stats.size.toString(),
               'Last-Modified': stats.mtime.toUTCString()
-            }, fs.createReadStream(_this.options.catchAll));
+            }, fs.createReadStream(_this.options.catchAllFile));
           });
         });
       }

--- a/src/hem.coffee
+++ b/src/hem.coffee
@@ -35,7 +35,8 @@ class Hem
     css:          './css'
     libs:         []
     public:       './public'
-    catchAll:     './public/index.html'
+    catchAll:     false
+    catchAllFile: './public/index.html'
     paths:        ['./app']
     dependencies: []
     port:         process.env.PORT or argv.port or 9294
@@ -70,14 +71,14 @@ class Hem
     if path.existsSync(@options.public)
       @app.use(strata.static, @options.public, ['index.html', 'index.htm'])
 
-    if path.existsSync(@options.catchAll)
+    if @options.catchAll and path.existsSync(@options.catchAllFile)
       @app.get /.+/, (env, callback) =>
-        fs.stat @options.catchAll, (err, stats) =>
+        fs.stat @options.catchAllFile, (err, stats) =>
           callback 200,
             'Content-Type': 'text/html'
             'Content-Length': stats.size.toString(),
             'Last-Modified': stats.mtime.toUTCString()
-            fs.createReadStream(@options.catchAll)
+            fs.createReadStream(@options.catchAllFile)
 
     strata.run(@app, port: @options.port)
 


### PR DESCRIPTION
Implemented a catch-all configuration to use with HTML5 pushState for returning same page for all urls that would otherwise return 404, as discussed in issue #35.
