### PR TITLE
declarative use of alternate view compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,61 @@ This is rather awesome, as it means you don't need to faff around with coping ar
 #Usage
 
 Please see the [Hem guide](http://spinejs.com/docs/hem) for usage instructions.
+
+# Using compilers
+People have different opinions about their preferred flavor of templating. Rather than extend
+hem and carry along all the dependencies of the compilers, you can now extend hem declaritively.
+
+1. Add the npm module that provides the hem-compiler implementation to your package.json
+2. Declare the mapping of file extension to the module in slug.json
+3. Write your templates in your preferred format
+
+Known compilers:
+
+* [hem-compiler-haml](https://github.com/deafgreatdane/hem-compiler-haml)
+
+Sample slug.json
+
+    {
+        "dependencies": [
+            "es5-shimify",
+            "json2ify",
+            "jqueryify",
+            "spine",
+            "spine/lib/local",
+            "spine/lib/ajax",
+            "spine/lib/route",
+            "spine/lib/manager"
+        ],
+        "libs": [],
+        "compilers":{
+           "haml":"hem-compiler-haml"
+        }
+    }
+
+
+## Writing new compilers
+Each compiler is encapsulated in an npm package. This package is probably just a shim, delegating
+the compilation to the actual package, but wrapping it a way that makes in friendly to hem's conventions.
+
+The package should export a single function called "compile" that takes a single file path argument and
+returns a string that represents the module definition to be used on the client.
+
+For example, here's the extent of the definition for using haml (as encapsulated in the [hem-compiler-haml](http://github.com/deafgreatdane/hem-compiler-haml) package
+
+    var HamlCoffee = require('haml-coffee/lib/haml-coffee');
+    var CoffeeScript = require('coffee-script')
+    var fs   = require('fs');
+
+    var compile = function(path) {
+      var compiler, content, template;
+      compiler = new HamlCoffee({});
+      content = fs.readFileSync(path, 'utf8');
+      compiler.parse(content);
+      template = compiler.precompile();
+      template = CoffeeScript.compile(template);
+      return "module.exports = (function(data){ return (function(){ return " + template + " }).call(data); })";
+    };
+
+    module.exports.compile = compile;
+

--- a/lib/hem.js
+++ b/lib/hem.js
@@ -168,6 +168,7 @@
     Hem.prototype.hemPackage = function() {
       return pkg.createPackage({
         dependencies: this.options.dependencies,
+        compilers: this.options.compilers,
         paths: this.options.paths,
         libs: this.options.libs
       });

--- a/lib/package.js
+++ b/lib/package.js
@@ -21,6 +21,7 @@
   Package = (function() {
 
     function Package(config) {
+      var ext, mod, _ref;
       if (config == null) {
         config = {};
       }
@@ -28,6 +29,13 @@
       this.libs = toArray(config.libs);
       this.paths = toArray(config.paths);
       this.dependencies = toArray(config.dependencies);
+      if ((config.compilers != null)) {
+        _ref = config.compilers;
+        for (ext in _ref) {
+          mod = _ref[ext];
+          compilers[ext] = require(mod).compile;
+        }
+      }
     }
 
     Package.prototype.compileModules = function() {

--- a/src/hem.coffee
+++ b/src/hem.coffee
@@ -104,6 +104,7 @@ class Hem
   hemPackage: ->
     pkg.createPackage(
       dependencies: @options.dependencies
+      compilers: @options.compilers
       paths: @options.paths
       libs: @options.libs
     )

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -13,6 +13,9 @@ class Package
     @libs         = toArray(config.libs)
     @paths        = toArray(config.paths)
     @dependencies = toArray(config.dependencies)
+    if ( config.compilers?)
+      for ext, mod of config.compilers
+        compilers[ext] = require(mod).compile
 
   compileModules: ->
     @dependency or= new Dependency(@dependencies)


### PR DESCRIPTION
I see a lot of open issues and other pull requests to incorporate other view templating languagesinto hem. I imagine one concern is the increased dependency of hem on varieties of other modules, when a given user of hem probably only uses one of them.

This adds a "compilers" map to slug.json, allowing custom packages to provide shims to the other compilers. Then the app that's using spine and wants an alternate view language can add its own dependency.

In addition to avoiding cluttering hem with dependencies, it also allows users to avoid using the slug.js convention that hem has promoted to-date.
