### PR TITLE
Update stylus version for node 8 compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "uglify-js": "~1.1.1",
     "fast-detective": "~0.0.1",
     "optimist": "~0.2.6",
-    "stylus" : "~0.23.0",
+    "stylus" : "~0.27.0",
     "coffee-script" : "~1.3.0",
     "watch" : "~0.4.0",
     "strata": "0.15.1"


### PR DESCRIPTION
hem won't install in node 8 unless the stylus version is updated.

stylus 0.26.1 was the first version to support node 8, I've bumped it to ~0.27.0 though.
