### PR TITLE
hem server host option correction in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Now, we can start a development server, which will dynamically build our applica
 By default, your spine application is served at http://localhost:9294. 
 You can configure the host and port from command line or as settings in your package.json
 
-    hem server -p 9295 -host 192.168.1.1
+    hem server -p 9295 --host 192.168.1.1
     
 Would result in your application being served at http://192.168.1.1:9295/
 


### PR DESCRIPTION
In the docs the hem server option for host is written with only one
hyphen, which will not work. Optimist will parse -host x.x.x.x as
h:true, o:true, s:true and t: x.x.x.x (and test:x.x.x.x since there is
an alias for t)

The solution is to add a hyphen to the docs: --host or add an alias for
-h in hem.coffee
