### PR TITLE
Fix: Added .litcoffee compile support (CoffeeScript 1.5.0)

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -21,9 +21,15 @@
 
   try {
     cs = require('coffee-script');
-    compilers.litcoffee = compilers.coffee = function(path) {
+    compilers.coffee = function(path) {
       return cs.compile(fs.readFileSync(path, 'utf8'), {
         filename: path
+      });
+    };
+    compilers.litcoffee = function(path) {
+      return cs.compile(fs.readFileSync(path, 'utf8'), {
+        filename: path,
+        literate: true
       });
     };
   } catch (err) {

--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -11,8 +11,11 @@ require.extensions['.css'] = (module, filename) ->
 
 try
   cs = require 'coffee-script'
-  compilers.litcoffee = compilers.coffee = (path) ->
+  compilers.coffee = (path) ->
     cs.compile(fs.readFileSync(path, 'utf8'), filename: path)
+    
+  compilers.litcoffee = (path) ->
+    cs.compile(fs.readFileSync(path, 'utf8'), filename: path, literate: true)
 catch err
 
 eco = require 'eco'


### PR DESCRIPTION
Added litcoffee support took a little more then I hoped for... In the command line you can use `coffee -c somefile.litcoffee` but in code you have to say it is a literate file:

```
compilers.litcoffee = (path) ->
  cs.compile(fs.readFileSync(path, 'utf8'), filename: path, literate: true)
```

I tested it, and it works now. Sorry for the last pull request which was untested.
