### PR TITLE
BugFix for change in jade API

### DIFF
--- a/src/compilers.coffee
+++ b/src/compilers.coffee
@@ -77,10 +77,9 @@ try
   compilers.jade = (path) ->
     content = fs.readFileSync(path, 'utf8')
     try
-      template = jade.compile content,
+      template = jade.compileClient content,
         filename: path
         compileDebug: compilers.DEBUG
-        client: true
       source = template.toString()
       "module.exports = #{source};"
     catch ex


### PR DESCRIPTION
It seems that Jade has changed it's API. 
When I create the default spine skeleton app with spine.app, and run it with "hem server". I get the following error:

```
   > hem server
   Starting Server at :9294 
   Error: The `client` option is deprecated, use `jade.compileClient`
       at Function.res.toString (/usr/local/lib/node_modules/hem/node_modules/jade/lib/jade.js:164:17)
       at Object.compilers.jade (/usr/local/lib/node_modules/hem/lib/compilers.js:107:27)
       at Module.compile (/usr/local/lib/node_modules/hem/lib/stitch.js:86:33)
       at Object.<anonymous> (/usr/local/lib/node_modules/hem/assets/stitch.eco:76:105)
```

The little change in this pull request fixes this.   Please test this bugfix thoroughly. I am quite new to coffeescript and spine.
