### PR TITLE
Fix module resolver infinite loop for Windows

### DIFF
--- a/src/resolve.coffee
+++ b/src/resolve.coffee
@@ -20,6 +20,10 @@ modulerize = (id, filename = id) ->
 modulePaths = Module._nodeModulePaths(process.cwd())
 invalidDirs = ['/', '.']
 
+if global.process and global.process.platform is 'win32'
+  invalidDirs = (invalidDirs.concat(drive + ':\\' for drive in 'abcdefghijklmnopqrstuvwxyz')
+                            .concat(drive + ':\\' for drive in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
+
 repl =
   id: 'repl'
   filename: join(process.cwd(), 'repl')


### PR DESCRIPTION
The loop `while dir not in invalidDirs and dir not in modulePaths` could become an infinite loop on Windows because "C:\" is not in the list of invalid directories.

Could also do this another way, but this fix should handle 99.9% of the cases (there could also be a network share like "\share\some\path" but most developers don't use that directly).
